### PR TITLE
api: implement Google OAuth 2.0 flow and Calendar events endpoint

### DIFF
--- a/api/drizzle/0001_lowly_ghost_rider.sql
+++ b/api/drizzle/0001_lowly_ghost_rider.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "oauth_tokens" ADD CONSTRAINT "oauth_tokens_provider_unique" UNIQUE("provider");

--- a/api/drizzle/meta/0001_snapshot.json
+++ b/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1121 @@
+{
+  "id": "8ef432f2-1ae0-4011-af0d-f763405eec39",
+  "prevId": "0d26d5ed-6140-4990-b76f-ff5f1852d080",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_images_r2_key": {
+          "name": "idx_images_r2_key",
+          "columns": [
+            {
+              "expression": "r2_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "images_r2_key_unique": {
+          "name": "images_r2_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["r2_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.labels": {
+      "name": "labels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "labels_name_unique": {
+          "name": "labels_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_tokens": {
+      "name": "oauth_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'google_calendar'"
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_tokens_provider_unique": {
+          "name": "oauth_tokens_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_projects_status": {
+          "name": "idx_projects_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_projects_sort_order": {
+          "name": "idx_projects_sort_order",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recurrence_rules": {
+      "name": "recurrence_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurrence_rule_id": {
+          "name": "recurrence_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_recurrence_rule_id": {
+          "name": "idx_schedules_recurrence_rule_id",
+          "columns": [
+            {
+              "expression": "recurrence_rule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_context": {
+          "name": "idx_schedules_context",
+          "columns": [
+            {
+              "expression": "context",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "schedules_recurrence_rule_id_recurrence_rules_id_fk": {
+          "name": "schedules_recurrence_rule_id_recurrence_rules_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "recurrence_rules",
+          "columnsFrom": ["recurrence_rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_comments": {
+      "name": "task_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_task_comments_task_id": {
+          "name": "idx_task_comments_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_comments_created_at": {
+          "name": "idx_task_comments_created_at",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_comments_task_id_tasks_id_fk": {
+          "name": "task_comments_task_id_tasks_id_fk",
+          "tableFrom": "task_comments",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_labels": {
+      "name": "task_labels",
+      "schema": "",
+      "columns": {
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_task_labels_task_id": {
+          "name": "idx_task_labels_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_task_labels_label_id": {
+          "name": "idx_task_labels_label_id",
+          "columns": [
+            {
+              "expression": "label_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_labels_task_id_tasks_id_fk": {
+          "name": "task_labels_task_id_tasks_id_fk",
+          "tableFrom": "task_labels",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_labels_label_id_labels_id_fk": {
+          "name": "task_labels_label_id_labels_id_fk",
+          "tableFrom": "task_labels",
+          "tableTo": "labels",
+          "columnsFrom": ["label_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "task_labels_task_id_label_id_pk": {
+          "name": "task_labels_task_id_label_id_pk",
+          "columns": ["task_id", "label_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task_pages": {
+      "name": "task_pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_task_pages_task_id": {
+          "name": "idx_task_pages_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_pages_task_id_tasks_id_fk": {
+          "name": "task_pages_task_id_tasks_id_fk",
+          "tableFrom": "task_pages",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_minutes": {
+          "name": "estimated_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule_id": {
+          "name": "recurrence_rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tasks_parent_id": {
+          "name": "idx_tasks_parent_id",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_status": {
+          "name": "idx_tasks_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_start_date": {
+          "name": "idx_tasks_start_date",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_due_date": {
+          "name": "idx_tasks_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_project_id": {
+          "name": "idx_tasks_project_id",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_project_status": {
+          "name": "idx_tasks_project_status",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_parent_id_tasks_id_fk": {
+          "name": "tasks_parent_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_recurrence_rule_id_recurrence_rules_id_fk": {
+          "name": "tasks_recurrence_rule_id_recurrence_rules_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "recurrence_rules",
+          "columnsFrom": ["recurrence_rule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.time_blocks": {
+      "name": "time_blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_scheduled": {
+          "name": "is_auto_scheduled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_time_blocks_task_id": {
+          "name": "idx_time_blocks_task_id",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_time_blocks_date_range": {
+          "name": "idx_time_blocks_date_range",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "time_blocks_task_id_tasks_id_fk": {
+          "name": "time_blocks_task_id_tasks_id_fk",
+          "tableFrom": "time_blocks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.today_tasks": {
+      "name": "today_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "today_tasks_task_id_tasks_id_fk": {
+          "name": "today_tasks_task_id_tasks_id_fk",
+          "tableFrom": "today_tasks",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773756536311,
       "tag": "0000_panoramic_whizzer",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1774163700616,
+      "tag": "0001_lowly_ghost_rider",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/db/schema.ts
+++ b/api/src/db/schema.ts
@@ -274,7 +274,7 @@ export const oauthTokens = pgTable('oauth_tokens', {
   id: text('id')
     .primaryKey()
     .$defaultFn(() => crypto.randomUUID()),
-  provider: text('provider').notNull().default('google_calendar'),
+  provider: text('provider').notNull().default('google_calendar').unique(),
   accessToken: text('access_token').notNull(),
   refreshToken: text('refresh_token').notNull(),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),

--- a/api/src/routes/calendar.ts
+++ b/api/src/routes/calendar.ts
@@ -2,6 +2,7 @@ import {
   getAuthUrl,
   getEvents,
   handleOAuthCallback,
+  OAuthTokenMissingError,
 } from '@api/services/google-calendar'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
@@ -25,13 +26,12 @@ export const calendarApp = new Hono()
       const events = await getEvents(calendarId, timeMin, timeMax)
       return c.json(events, 200)
     } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Unknown error occurred'
-
-      if (message.includes('No OAuth token found')) {
-        return c.json({ error: message }, 401)
+      if (error instanceof OAuthTokenMissingError) {
+        return c.json({ error: error.message }, 401)
       }
 
+      const message =
+        error instanceof Error ? error.message : 'Unknown error occurred'
       return c.json({ error: message }, 500)
     }
   })

--- a/api/src/routes/calendar.ts
+++ b/api/src/routes/calendar.ts
@@ -1,3 +1,8 @@
+import {
+  getAuthUrl,
+  getEvents,
+  handleOAuthCallback,
+} from '@api/services/google-calendar'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
@@ -8,17 +13,51 @@ const eventsQuerySchema = z.object({
   timeMax: z.string().datetime(),
 })
 
+const callbackQuerySchema = z.object({
+  code: z.string(),
+})
+
 export const calendarApp = new Hono()
-  .get('/events', zValidator('query', eventsQuerySchema), (c) => {
-    // TODO: implement Google Calendar events retrieval
-    return c.json([], 200)
+  .get('/events', zValidator('query', eventsQuerySchema), async (c) => {
+    const { calendarId, timeMin, timeMax } = c.req.valid('query')
+
+    try {
+      const events = await getEvents(calendarId, timeMin, timeMax)
+      return c.json(events, 200)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+
+      if (message.includes('No OAuth token found')) {
+        return c.json({ error: message }, 401)
+      }
+
+      return c.json({ error: message }, 500)
+    }
   })
   .get('/auth-url', (c) => {
-    // TODO: implement OAuth auth URL generation
-    return c.json({ message: 'not implemented' }, 501)
+    try {
+      const url = getAuthUrl()
+      return c.json({ url }, 200)
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+      return c.json({ error: message }, 500)
+    }
   })
-  .get('/oauth-callback', (c) => {
-    // TODO: implement OAuth callback handling
-    void c.req.query('code')
-    return c.json({ message: 'not implemented' }, 501)
-  })
+  .get(
+    '/oauth-callback',
+    zValidator('query', callbackQuerySchema),
+    async (c) => {
+      const { code } = c.req.valid('query')
+
+      try {
+        await handleOAuthCallback(code)
+        return c.json({ message: 'Authentication successful' }, 200)
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error occurred'
+        return c.json({ error: message }, 400)
+      }
+    },
+  )

--- a/api/src/services/google-calendar.test.ts
+++ b/api/src/services/google-calendar.test.ts
@@ -172,6 +172,41 @@ describe('refreshTokenIfNeeded', () => {
     )
   })
 
+  it('persists rotated refresh token when Google returns one', async () => {
+    const { refreshTokenIfNeeded } = await importService()
+
+    await upsertToken({
+      accessToken: 'old-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: new Date(Date.now() - 1000),
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: 'new-access',
+          refresh_token: 'rotated-refresh-token',
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    )
+
+    await refreshTokenIfNeeded()
+
+    const [updated] = await db
+      .select()
+      .from(oauthTokens)
+      .where(eq(oauthTokens.provider, 'google_calendar'))
+      .limit(1)
+    expect(updated).toEqual(
+      expect.objectContaining({
+        accessToken: 'new-access',
+        refreshToken: 'rotated-refresh-token',
+      }),
+    )
+  })
+
   it('throws OAuthTokenMissingError when no token exists', async () => {
     const { refreshTokenIfNeeded, OAuthTokenMissingError } =
       await importService()

--- a/api/src/services/google-calendar.test.ts
+++ b/api/src/services/google-calendar.test.ts
@@ -24,6 +24,20 @@ function clearEnv() {
   }
 }
 
+async function upsertToken(values: {
+  accessToken: string
+  refreshToken: string
+  expiresAt: Date
+}) {
+  await db
+    .insert(oauthTokens)
+    .values({ provider: 'google_calendar', ...values })
+    .onConflictDoUpdate({
+      target: oauthTokens.provider,
+      set: { ...values, updatedAt: new Date() },
+    })
+}
+
 beforeEach(() => {
   setEnv()
 })
@@ -116,11 +130,10 @@ describe('refreshTokenIfNeeded', () => {
   it('returns existing token when not expired', async () => {
     const { refreshTokenIfNeeded } = await importService()
 
-    await db.insert(oauthTokens).values({
-      provider: 'google_calendar',
+    await upsertToken({
       accessToken: 'valid-token',
       refreshToken: 'refresh-token',
-      expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour from now
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
     })
 
     const token = await refreshTokenIfNeeded()
@@ -130,11 +143,10 @@ describe('refreshTokenIfNeeded', () => {
   it('refreshes token when close to expiry', async () => {
     const { refreshTokenIfNeeded } = await importService()
 
-    await db.insert(oauthTokens).values({
-      provider: 'google_calendar',
+    await upsertToken({
       accessToken: 'expired-token',
       refreshToken: 'refresh-token',
-      expiresAt: new Date(Date.now() + 60 * 1000), // 1 minute from now (within 5-min buffer)
+      expiresAt: new Date(Date.now() + 60 * 1000), // within 5-min buffer
     })
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
@@ -150,7 +162,6 @@ describe('refreshTokenIfNeeded', () => {
     const token = await refreshTokenIfNeeded()
     expect(token).toBe('refreshed-token')
 
-    // Verify DB was updated
     const [updated] = await db
       .select()
       .from(oauthTokens)
@@ -161,20 +172,25 @@ describe('refreshTokenIfNeeded', () => {
     )
   })
 
-  it('throws when no token exists', async () => {
-    const { refreshTokenIfNeeded } = await importService()
+  it('throws OAuthTokenMissingError when no token exists', async () => {
+    const { refreshTokenIfNeeded, OAuthTokenMissingError } =
+      await importService()
 
-    await expect(refreshTokenIfNeeded()).rejects.toThrow('No OAuth token found')
+    // Ensure no token exists by deleting any leftover
+    await db
+      .delete(oauthTokens)
+      .where(eq(oauthTokens.provider, 'google_calendar'))
+
+    await expect(refreshTokenIfNeeded()).rejects.toThrow(OAuthTokenMissingError)
   })
 
   it('throws when refresh request fails', async () => {
     const { refreshTokenIfNeeded } = await importService()
 
-    await db.insert(oauthTokens).values({
-      provider: 'google_calendar',
+    await upsertToken({
       accessToken: 'expired-token',
       refreshToken: 'bad-refresh-token',
-      expiresAt: new Date(Date.now() - 1000), // already expired
+      expiresAt: new Date(Date.now() - 1000),
     })
 
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
@@ -189,9 +205,7 @@ describe('getEvents', () => {
   it('fetches and transforms Google Calendar events', async () => {
     const { getEvents } = await importService()
 
-    // Insert a valid token
-    await db.insert(oauthTokens).values({
-      provider: 'google_calendar',
+    await upsertToken({
       accessToken: 'valid-token',
       refreshToken: 'refresh-token',
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),
@@ -248,8 +262,7 @@ describe('getEvents', () => {
   it('handles events without summary', async () => {
     const { getEvents } = await importService()
 
-    await db.insert(oauthTokens).values({
-      provider: 'google_calendar',
+    await upsertToken({
       accessToken: 'valid-token',
       refreshToken: 'refresh-token',
       expiresAt: new Date(Date.now() + 60 * 60 * 1000),

--- a/api/src/services/google-calendar.test.ts
+++ b/api/src/services/google-calendar.test.ts
@@ -90,10 +90,13 @@ describe('handleOAuthCallback', () => {
       .where(eq(oauthTokens.provider, 'google_calendar'))
       .limit(1)
 
-    expect(savedToken).toBeDefined()
-    expect(savedToken!.accessToken).toBe('new-access-token')
-    expect(savedToken!.refreshToken).toBe('new-refresh-token')
-    expect(savedToken!.expiresAt.getTime()).toBeGreaterThan(Date.now())
+    expect(savedToken).toEqual(
+      expect.objectContaining({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+      }),
+    )
+    expect(savedToken?.expiresAt.getTime()).toBeGreaterThan(Date.now())
   })
 
   it('throws when token exchange fails', async () => {
@@ -153,7 +156,9 @@ describe('refreshTokenIfNeeded', () => {
       .from(oauthTokens)
       .where(eq(oauthTokens.provider, 'google_calendar'))
       .limit(1)
-    expect(updated!.accessToken).toBe('refreshed-token')
+    expect(updated).toEqual(
+      expect.objectContaining({ accessToken: 'refreshed-token' }),
+    )
   })
 
   it('throws when no token exists', async () => {
@@ -271,6 +276,6 @@ describe('getEvents', () => {
       '2026-03-23T00:00:00Z',
     )
 
-    expect(events[0]!.summary).toBe('(No title)')
+    expect(events).toEqual([expect.objectContaining({ summary: '(No title)' })])
   })
 })

--- a/api/src/services/google-calendar.test.ts
+++ b/api/src/services/google-calendar.test.ts
@@ -1,0 +1,276 @@
+import { db } from '@api/db/connection'
+import { oauthTokens } from '@api/db/schema'
+import { setupTestDb } from '@api/testing'
+import { eq } from 'drizzle-orm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+setupTestDb()
+
+const MOCK_ENV = {
+  GOOGLE_CLIENT_ID: 'test-client-id',
+  GOOGLE_CLIENT_SECRET: 'test-client-secret',
+  GOOGLE_REDIRECT_URI: 'http://localhost:3001/api/calendar/oauth-callback',
+}
+
+function setEnv() {
+  for (const [key, value] of Object.entries(MOCK_ENV)) {
+    process.env[key] = value
+  }
+}
+
+function clearEnv() {
+  for (const key of Object.keys(MOCK_ENV)) {
+    delete process.env[key]
+  }
+}
+
+beforeEach(() => {
+  setEnv()
+})
+
+afterEach(() => {
+  clearEnv()
+  vi.restoreAllMocks()
+})
+
+// Dynamically import to allow env vars to be set before module evaluation
+async function importService() {
+  return await import('@api/services/google-calendar')
+}
+
+describe('getAuthUrl', () => {
+  it('returns a Google OAuth authorization URL with correct parameters', async () => {
+    const { getAuthUrl } = await importService()
+
+    const url = getAuthUrl()
+    const parsed = new URL(url)
+
+    expect(parsed.origin + parsed.pathname).toBe(
+      'https://accounts.google.com/o/oauth2/v2/auth',
+    )
+    expect(parsed.searchParams.get('client_id')).toBe('test-client-id')
+    expect(parsed.searchParams.get('redirect_uri')).toBe(
+      'http://localhost:3001/api/calendar/oauth-callback',
+    )
+    expect(parsed.searchParams.get('scope')).toBe(
+      'https://www.googleapis.com/auth/calendar.readonly',
+    )
+    expect(parsed.searchParams.get('access_type')).toBe('offline')
+    expect(parsed.searchParams.get('response_type')).toBe('code')
+  })
+
+  it('throws when environment variables are missing', async () => {
+    clearEnv()
+    const { getAuthUrl } = await importService()
+
+    expect(() => getAuthUrl()).toThrow('environment variables are required')
+  })
+})
+
+describe('handleOAuthCallback', () => {
+  it('exchanges code for tokens and saves them to the database', async () => {
+    const { handleOAuthCallback } = await importService()
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: 'new-access-token',
+          refresh_token: 'new-refresh-token',
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    )
+
+    await handleOAuthCallback('auth-code-123')
+
+    const [savedToken] = await db
+      .select()
+      .from(oauthTokens)
+      .where(eq(oauthTokens.provider, 'google_calendar'))
+      .limit(1)
+
+    expect(savedToken).toBeDefined()
+    expect(savedToken!.accessToken).toBe('new-access-token')
+    expect(savedToken!.refreshToken).toBe('new-refresh-token')
+    expect(savedToken!.expiresAt.getTime()).toBeGreaterThan(Date.now())
+  })
+
+  it('throws when token exchange fails', async () => {
+    const { handleOAuthCallback } = await importService()
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('invalid_grant', { status: 400 }),
+    )
+
+    await expect(handleOAuthCallback('bad-code')).rejects.toThrow(
+      'Token exchange failed',
+    )
+  })
+})
+
+describe('refreshTokenIfNeeded', () => {
+  it('returns existing token when not expired', async () => {
+    const { refreshTokenIfNeeded } = await importService()
+
+    await db.insert(oauthTokens).values({
+      provider: 'google_calendar',
+      accessToken: 'valid-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour from now
+    })
+
+    const token = await refreshTokenIfNeeded()
+    expect(token).toBe('valid-token')
+  })
+
+  it('refreshes token when close to expiry', async () => {
+    const { refreshTokenIfNeeded } = await importService()
+
+    await db.insert(oauthTokens).values({
+      provider: 'google_calendar',
+      accessToken: 'expired-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() + 60 * 1000), // 1 minute from now (within 5-min buffer)
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: 'refreshed-token',
+          expires_in: 3600,
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const token = await refreshTokenIfNeeded()
+    expect(token).toBe('refreshed-token')
+
+    // Verify DB was updated
+    const [updated] = await db
+      .select()
+      .from(oauthTokens)
+      .where(eq(oauthTokens.provider, 'google_calendar'))
+      .limit(1)
+    expect(updated!.accessToken).toBe('refreshed-token')
+  })
+
+  it('throws when no token exists', async () => {
+    const { refreshTokenIfNeeded } = await importService()
+
+    await expect(refreshTokenIfNeeded()).rejects.toThrow('No OAuth token found')
+  })
+
+  it('throws when refresh request fails', async () => {
+    const { refreshTokenIfNeeded } = await importService()
+
+    await db.insert(oauthTokens).values({
+      provider: 'google_calendar',
+      accessToken: 'expired-token',
+      refreshToken: 'bad-refresh-token',
+      expiresAt: new Date(Date.now() - 1000), // already expired
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response('invalid_grant', { status: 400 }),
+    )
+
+    await expect(refreshTokenIfNeeded()).rejects.toThrow('Token refresh failed')
+  })
+})
+
+describe('getEvents', () => {
+  it('fetches and transforms Google Calendar events', async () => {
+    const { getEvents } = await importService()
+
+    // Insert a valid token
+    await db.insert(oauthTokens).values({
+      provider: 'google_calendar',
+      accessToken: 'valid-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: 'event-1',
+              summary: 'Team standup',
+              start: { dateTime: '2026-03-22T09:00:00Z' },
+              end: { dateTime: '2026-03-22T09:30:00Z' },
+            },
+            {
+              id: 'event-2',
+              summary: 'All-day event',
+              start: { date: '2026-03-22' },
+              end: { date: '2026-03-23' },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const events = await getEvents(
+      'primary',
+      '2026-03-22T00:00:00Z',
+      '2026-03-23T00:00:00Z',
+    )
+
+    expect(events).toEqual([
+      {
+        id: 'event-1',
+        summary: 'Team standup',
+        startTime: '2026-03-22T09:00:00Z',
+        endTime: '2026-03-22T09:30:00Z',
+        isAllDay: false,
+        source: 'google_calendar',
+      },
+      {
+        id: 'event-2',
+        summary: 'All-day event',
+        startTime: '2026-03-22',
+        endTime: '2026-03-23',
+        isAllDay: true,
+        source: 'google_calendar',
+      },
+    ])
+  })
+
+  it('handles events without summary', async () => {
+    const { getEvents } = await importService()
+
+    await db.insert(oauthTokens).values({
+      provider: 'google_calendar',
+      accessToken: 'valid-token',
+      refreshToken: 'refresh-token',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    })
+
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          items: [
+            {
+              id: 'event-no-title',
+              start: { dateTime: '2026-03-22T10:00:00Z' },
+              end: { dateTime: '2026-03-22T11:00:00Z' },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+
+    const events = await getEvents(
+      'primary',
+      '2026-03-22T00:00:00Z',
+      '2026-03-23T00:00:00Z',
+    )
+
+    expect(events[0]!.summary).toBe('(No title)')
+  })
+})

--- a/api/src/services/google-calendar.ts
+++ b/api/src/services/google-calendar.ts
@@ -1,6 +1,7 @@
 import { db } from '@api/db/connection'
 import { oauthTokens } from '@api/db/schema'
 import { eq } from 'drizzle-orm'
+import { z } from 'zod'
 
 const GOOGLE_AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
 const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
@@ -10,6 +11,41 @@ const PROVIDER = 'google_calendar'
 
 // Token refresh buffer: refresh 5 minutes before expiry
 const REFRESH_BUFFER_MS = 5 * 60 * 1000
+
+export class OAuthTokenMissingError extends Error {
+  constructor() {
+    super('No OAuth token found. Please authenticate first.')
+    this.name = 'OAuthTokenMissingError'
+  }
+}
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string(),
+  expires_in: z.number(),
+})
+
+const refreshTokenResponseSchema = z.object({
+  access_token: z.string(),
+  expires_in: z.number(),
+})
+
+const googleCalendarEventSchema = z.object({
+  id: z.string(),
+  summary: z.string().optional(),
+  start: z.object({
+    dateTime: z.string().optional(),
+    date: z.string().optional(),
+  }),
+  end: z.object({
+    dateTime: z.string().optional(),
+    date: z.string().optional(),
+  }),
+})
+
+const googleCalendarEventsResponseSchema = z.object({
+  items: z.array(googleCalendarEventSchema).optional(),
+})
 
 function getConfig() {
   const clientId = process.env['GOOGLE_CLIENT_ID']
@@ -60,22 +96,26 @@ export async function handleOAuthCallback(code: string): Promise<void> {
     throw new Error(`Token exchange failed: ${error}`)
   }
 
-  const data = (await response.json()) as {
-    access_token: string
-    refresh_token: string
-    expires_in: number
-  }
-
+  const data = tokenResponseSchema.parse(await response.json())
   const expiresAt = new Date(Date.now() + data.expires_in * 1000)
 
-  // Upsert: delete existing token for this provider, then insert new one
-  await db.delete(oauthTokens).where(eq(oauthTokens.provider, PROVIDER))
-  await db.insert(oauthTokens).values({
-    provider: PROVIDER,
-    accessToken: data.access_token,
-    refreshToken: data.refresh_token,
-    expiresAt,
-  })
+  await db
+    .insert(oauthTokens)
+    .values({
+      provider: PROVIDER,
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt,
+    })
+    .onConflictDoUpdate({
+      target: oauthTokens.provider,
+      set: {
+        accessToken: data.access_token,
+        refreshToken: data.refresh_token,
+        expiresAt,
+        updatedAt: new Date(),
+      },
+    })
 }
 
 export async function refreshTokenIfNeeded(): Promise<string> {
@@ -86,7 +126,7 @@ export async function refreshTokenIfNeeded(): Promise<string> {
     .limit(1)
 
   if (!token) {
-    throw new Error('No OAuth token found. Please authenticate first.')
+    throw new OAuthTokenMissingError()
   }
 
   // Return existing token if not expired
@@ -113,11 +153,7 @@ export async function refreshTokenIfNeeded(): Promise<string> {
     throw new Error(`Token refresh failed: ${error}`)
   }
 
-  const data = (await response.json()) as {
-    access_token: string
-    expires_in: number
-  }
-
+  const data = refreshTokenResponseSchema.parse(await response.json())
   const expiresAt = new Date(Date.now() + data.expires_in * 1000)
 
   await db
@@ -139,17 +175,6 @@ export interface ExternalEvent {
   endTime: string
   isAllDay: boolean
   source: 'google_calendar'
-}
-
-interface GoogleCalendarEvent {
-  id: string
-  summary?: string
-  start: { dateTime?: string; date?: string }
-  end: { dateTime?: string; date?: string }
-}
-
-interface GoogleCalendarEventsResponse {
-  items?: GoogleCalendarEvent[]
 }
 
 export async function getEvents(
@@ -179,7 +204,7 @@ export async function getEvents(
     throw new Error(`Google Calendar API error: ${error}`)
   }
 
-  const data = (await response.json()) as GoogleCalendarEventsResponse
+  const data = googleCalendarEventsResponseSchema.parse(await response.json())
 
   return (data.items ?? []).map((event) => {
     const isAllDay = !event.start.dateTime

--- a/api/src/services/google-calendar.ts
+++ b/api/src/services/google-calendar.ts
@@ -1,0 +1,195 @@
+import { db } from '@api/db/connection'
+import { oauthTokens } from '@api/db/schema'
+import { eq } from 'drizzle-orm'
+
+const GOOGLE_AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
+const GOOGLE_CALENDAR_API_BASE = 'https://www.googleapis.com/calendar/v3'
+const SCOPES = 'https://www.googleapis.com/auth/calendar.readonly'
+const PROVIDER = 'google_calendar'
+
+// Token refresh buffer: refresh 5 minutes before expiry
+const REFRESH_BUFFER_MS = 5 * 60 * 1000
+
+function getConfig() {
+  const clientId = process.env['GOOGLE_CLIENT_ID']
+  const clientSecret = process.env['GOOGLE_CLIENT_SECRET']
+  const redirectUri = process.env['GOOGLE_REDIRECT_URI']
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    throw new Error(
+      'GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REDIRECT_URI environment variables are required',
+    )
+  }
+
+  return { clientId, clientSecret, redirectUri }
+}
+
+export function getAuthUrl(): string {
+  const { clientId, redirectUri } = getConfig()
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: 'code',
+    scope: SCOPES,
+    access_type: 'offline',
+    prompt: 'consent',
+  })
+
+  return `${GOOGLE_AUTH_ENDPOINT}?${params.toString()}`
+}
+
+export async function handleOAuthCallback(code: string): Promise<void> {
+  const { clientId, clientSecret, redirectUri } = getConfig()
+
+  const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Token exchange failed: ${error}`)
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    refresh_token: string
+    expires_in: number
+  }
+
+  const expiresAt = new Date(Date.now() + data.expires_in * 1000)
+
+  // Upsert: delete existing token for this provider, then insert new one
+  await db.delete(oauthTokens).where(eq(oauthTokens.provider, PROVIDER))
+  await db.insert(oauthTokens).values({
+    provider: PROVIDER,
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt,
+  })
+}
+
+export async function refreshTokenIfNeeded(): Promise<string> {
+  const [token] = await db
+    .select()
+    .from(oauthTokens)
+    .where(eq(oauthTokens.provider, PROVIDER))
+    .limit(1)
+
+  if (!token) {
+    throw new Error('No OAuth token found. Please authenticate first.')
+  }
+
+  // Return existing token if not expired
+  if (token.expiresAt.getTime() > Date.now() + REFRESH_BUFFER_MS) {
+    return token.accessToken
+  }
+
+  // Refresh the token
+  const { clientId, clientSecret } = getConfig()
+
+  const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: token.refreshToken,
+      grant_type: 'refresh_token',
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Token refresh failed: ${error}`)
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    expires_in: number
+  }
+
+  const expiresAt = new Date(Date.now() + data.expires_in * 1000)
+
+  await db
+    .update(oauthTokens)
+    .set({
+      accessToken: data.access_token,
+      expiresAt,
+      updatedAt: new Date(),
+    })
+    .where(eq(oauthTokens.id, token.id))
+
+  return data.access_token
+}
+
+export interface ExternalEvent {
+  id: string
+  summary: string
+  startTime: string
+  endTime: string
+  isAllDay: boolean
+  source: 'google_calendar'
+}
+
+interface GoogleCalendarEvent {
+  id: string
+  summary?: string
+  start: { dateTime?: string; date?: string }
+  end: { dateTime?: string; date?: string }
+}
+
+interface GoogleCalendarEventsResponse {
+  items?: GoogleCalendarEvent[]
+}
+
+export async function getEvents(
+  calendarId: string,
+  timeMin: string,
+  timeMax: string,
+): Promise<ExternalEvent[]> {
+  const accessToken = await refreshTokenIfNeeded()
+
+  const params = new URLSearchParams({
+    timeMin,
+    timeMax,
+    singleEvents: 'true',
+    orderBy: 'startTime',
+  })
+
+  const response = await fetch(
+    `${GOOGLE_CALENDAR_API_BASE}/calendars/${encodeURIComponent(calendarId)}/events?${params.toString()}`,
+    {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  )
+
+  if (!response.ok) {
+    const error = await response.text()
+    throw new Error(`Google Calendar API error: ${error}`)
+  }
+
+  const data = (await response.json()) as GoogleCalendarEventsResponse
+
+  return (data.items ?? []).map((event) => {
+    const isAllDay = !event.start.dateTime
+    return {
+      id: event.id,
+      summary: event.summary ?? '(No title)',
+      startTime: event.start.dateTime ?? event.start.date ?? '',
+      endTime: event.end.dateTime ?? event.end.date ?? '',
+      isAllDay,
+      source: 'google_calendar' as const,
+    }
+  })
+}

--- a/api/src/services/google-calendar.ts
+++ b/api/src/services/google-calendar.ts
@@ -27,6 +27,7 @@ const tokenResponseSchema = z.object({
 
 const refreshTokenResponseSchema = z.object({
   access_token: z.string(),
+  refresh_token: z.string().optional(),
   expires_in: z.number(),
 })
 
@@ -162,6 +163,7 @@ export async function refreshTokenIfNeeded(): Promise<string> {
       accessToken: data.access_token,
       expiresAt,
       updatedAt: new Date(),
+      ...(data.refresh_token ? { refreshToken: data.refresh_token } : {}),
     })
     .where(eq(oauthTokens.id, token.id))
 


### PR DESCRIPTION
## Why

- tq's calendar view should display Google Calendar events as read-only, allowing users to see external appointments alongside tq tasks and identify available time slots
- OAuth 2.0 token acquisition and management is required as the foundation for this integration

## What

- Implement Google OAuth 2.0 authorization code flow (`/api/calendar/auth-url`, `/api/calendar/oauth-callback`)
- Implement automatic token refresh on expiry
- Add `/api/calendar/events` endpoint to fetch events from Google Calendar API

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/tq/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
