### PR TITLE
web: display recurring schedules on Day View calendar

### DIFF
--- a/web/src/components/calendar/calendar-grid.tsx
+++ b/web/src/components/calendar/calendar-grid.tsx
@@ -101,6 +101,7 @@ export const CalendarGrid = forwardRef<FullCalendar, CalendarGridProps>(
       title: event.title,
       start: event.start,
       end: event.end,
+      editable: event.type !== 'schedule',
       extendedProps: {
         type: event.type,
         duration: event.duration,

--- a/web/src/components/calendar/calendar-view.stories.tsx
+++ b/web/src/components/calendar/calendar-view.stories.tsx
@@ -14,6 +14,32 @@ function generateWeekEvents(): TimeBlockEvent[] {
     const d = new Date(today)
     d.setDate(d.getDate() + dayOffset)
     const ds = d.toISOString().slice(0, 10)
+    const nextD = new Date(d)
+    nextD.setDate(nextD.getDate() + 1)
+    const nextDs = nextD.toISOString().slice(0, 10)
+
+    // Daily recurring schedules
+    events.push(
+      {
+        id: `w-${String(dayOffset)}-sleep-pm`,
+        title: 'Sleep',
+        start: `${ds}T23:00:00`,
+        end: `${nextDs}T00:00:00`,
+        type: 'schedule',
+        color: { bg: '#2D2B55', accent: '#6C63FF' },
+        icon: 'moon',
+      },
+      {
+        id: `w-${String(dayOffset)}-sleep-am`,
+        title: 'Sleep',
+        start: `${ds}T00:00:00`,
+        end: `${ds}T07:00:00`,
+        type: 'schedule',
+        color: { bg: '#2D2B55', accent: '#6C63FF' },
+        icon: 'moon',
+      },
+    )
+
     events.push(
       {
         id: `w-${String(dayOffset)}-1`,
@@ -40,6 +66,18 @@ function generateWeekEvents(): TimeBlockEvent[] {
         end: `${ds}T15:00:00`,
         type: 'auto',
         duration: '1h',
+      })
+    }
+    // Gym schedule on weekdays only (Mon-Fri)
+    if (d.getDay() >= 1 && d.getDay() <= 5) {
+      events.push({
+        id: `w-${String(dayOffset)}-gym`,
+        title: 'Gym',
+        start: `${ds}T18:00:00`,
+        end: `${ds}T19:00:00`,
+        type: 'schedule',
+        color: { bg: '#1B4332', accent: '#52B788' },
+        icon: 'dumbbell',
       })
     }
   }
@@ -83,6 +121,10 @@ function generateMonthEvents(): TimeBlockEvent[] {
   }
   return events
 }
+
+const tomorrow = new Date(today)
+tomorrow.setDate(tomorrow.getDate() + 1)
+const tomorrowStr = `${String(tomorrow.getFullYear())}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
 
 const sampleEvents: TimeBlockEvent[] = [
   {
@@ -206,16 +248,58 @@ export const WeekViewWithDayEvents: Story = {
   },
 }
 
+export const SchedulesOnly: Story = {
+  args: {
+    events: [
+      {
+        id: 'sched-sleep-am',
+        title: 'Sleep',
+        start: `${dateStr}T00:00:00`,
+        end: `${dateStr}T07:00:00`,
+        type: 'schedule',
+        duration: '7h',
+        color: { bg: '#2D2B55', accent: '#6C63FF' },
+        icon: 'moon',
+      },
+      {
+        id: 'sched-gym',
+        title: 'Gym',
+        start: `${dateStr}T07:00:00`,
+        end: `${dateStr}T08:00:00`,
+        type: 'schedule',
+        duration: '1h',
+        color: { bg: '#1B4332', accent: '#52B788' },
+        icon: 'dumbbell',
+      },
+      {
+        id: 'sched-lunch',
+        title: 'Lunch',
+        start: `${dateStr}T12:00:00`,
+        end: `${dateStr}T13:00:00`,
+        type: 'schedule',
+        duration: '1h',
+        color: { bg: '#4D1A00', accent: '#FF8400' },
+      },
+      {
+        id: 'sched-sleep-pm',
+        title: 'Sleep',
+        start: `${dateStr}T23:00:00`,
+        end: `${tomorrowStr}T00:00:00`,
+        type: 'schedule',
+        duration: '1h',
+        color: { bg: '#2D2B55', accent: '#6C63FF' },
+        icon: 'moon',
+      },
+    ],
+  },
+}
+
 export const MonthViewEmpty: Story = {
   args: {
     events: [],
     initialView: 'month',
   },
 }
-
-const tomorrow = new Date(today)
-tomorrow.setDate(tomorrow.getDate() + 1)
-const tomorrowStr = `${String(tomorrow.getFullYear())}-${String(tomorrow.getMonth() + 1).padStart(2, '0')}-${String(tomorrow.getDate()).padStart(2, '0')}`
 
 export const OvernightEvents: Story = {
   args: {

--- a/web/src/lib/schedule-color.test.ts
+++ b/web/src/lib/schedule-color.test.ts
@@ -8,20 +8,21 @@ describe('scheduleColorToEventColor', () => {
   })
 
   it('uses the custom color as accent and darkens it for bg', () => {
+    // #52B788: R=82, G=183, B=136. With factor=0.7: R=25, G=55, B=41
     const result = scheduleColorToEventColor('#52B788')
-    expect(result.accent).toBe('#52B788')
-    // bg should be darker than the accent
-    expect(result.bg).not.toBe('#52B788')
-    expect(result.bg).toMatch(/^#[0-9a-f]{6}$/)
+    expect(result).toEqual({ accent: '#52B788', bg: '#193729' })
   })
 
-  it('returns a valid hex bg for various colors', () => {
-    const colors = ['#FF0000', '#00FF00', '#0000FF', '#FFFFFF', '#000000']
-    for (const color of colors) {
-      const result = scheduleColorToEventColor(color)
-      expect(result.accent).toBe(color)
-      expect(result.bg).toMatch(/^#[0-9a-f]{6}$/)
-    }
+  it('darkens white to 30% brightness', () => {
+    // #FFFFFF with factor=0.7: each channel 255 * 0.3 = 77 = 0x4d
+    const result = scheduleColorToEventColor('#FFFFFF')
+    expect(result).toEqual({ accent: '#FFFFFF', bg: '#4d4d4d' })
+  })
+
+  it('darkens pure red correctly', () => {
+    // #FF0000 with factor=0.7: R=255*0.3=77, G=0, B=0
+    const result = scheduleColorToEventColor('#FF0000')
+    expect(result).toEqual({ accent: '#FF0000', bg: '#4d0000' })
   })
 
   it('darkens black to black', () => {

--- a/web/src/lib/schedule-color.test.ts
+++ b/web/src/lib/schedule-color.test.ts
@@ -1,0 +1,31 @@
+import { scheduleColorToEventColor } from '@web/lib/schedule-color'
+import { describe, expect, it } from 'vitest'
+
+describe('scheduleColorToEventColor', () => {
+  it('returns default purple colors when color is null', () => {
+    const result = scheduleColorToEventColor(null)
+    expect(result).toEqual({ bg: '#2D2B55', accent: '#6C63FF' })
+  })
+
+  it('uses the custom color as accent and darkens it for bg', () => {
+    const result = scheduleColorToEventColor('#52B788')
+    expect(result.accent).toBe('#52B788')
+    // bg should be darker than the accent
+    expect(result.bg).not.toBe('#52B788')
+    expect(result.bg).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it('returns a valid hex bg for various colors', () => {
+    const colors = ['#FF0000', '#00FF00', '#0000FF', '#FFFFFF', '#000000']
+    for (const color of colors) {
+      const result = scheduleColorToEventColor(color)
+      expect(result.accent).toBe(color)
+      expect(result.bg).toMatch(/^#[0-9a-f]{6}$/)
+    }
+  })
+
+  it('darkens black to black', () => {
+    const result = scheduleColorToEventColor('#000000')
+    expect(result).toEqual({ bg: '#000000', accent: '#000000' })
+  })
+})

--- a/web/src/lib/schedule-color.ts
+++ b/web/src/lib/schedule-color.ts
@@ -27,7 +27,7 @@ export function scheduleColorToEventColor(color: string | null): {
 /**
  * Darken a hex color by mixing it with black.
  * @param hex - Hex color string (e.g., "#52B788")
- * @param factor - How much to darken (0 = black, 1 = original)
+ * @param factor - How much to darken (0 = original, 1 = black)
  */
 function darkenHex(hex: string, factor: number): string {
   const cleaned = hex.replace('#', '')

--- a/web/src/lib/schedule-color.ts
+++ b/web/src/lib/schedule-color.ts
@@ -1,0 +1,38 @@
+/**
+ * Default schedule colors when no custom color is set.
+ */
+const DEFAULT_BG = '#2D2B55'
+const DEFAULT_ACCENT = '#6C63FF'
+
+/**
+ * Convert a schedule's hex color to the { bg, accent } format used by EventBlock.
+ *
+ * The accent color is the schedule's custom color (or a default purple).
+ * The background is a darkened version of the accent to maintain readability.
+ */
+export function scheduleColorToEventColor(color: string | null): {
+  bg: string
+  accent: string
+} {
+  if (color == null || color === '') {
+    return { bg: DEFAULT_BG, accent: DEFAULT_ACCENT }
+  }
+
+  return {
+    bg: darkenHex(color, 0.7),
+    accent: color,
+  }
+}
+
+/**
+ * Darken a hex color by mixing it with black.
+ * @param hex - Hex color string (e.g., "#52B788")
+ * @param factor - How much to darken (0 = black, 1 = original)
+ */
+function darkenHex(hex: string, factor: number): string {
+  const cleaned = hex.replace('#', '')
+  const r = Math.round(Number.parseInt(cleaned.slice(0, 2), 16) * (1 - factor))
+  const g = Math.round(Number.parseInt(cleaned.slice(2, 4), 16) * (1 - factor))
+  const b = Math.round(Number.parseInt(cleaned.slice(4, 6), 16) * (1 - factor))
+  return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+}

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import type { CalendarDndCallbacks } from '@web/components/calendar/calendar-grid'
 import type { TimeBlockEvent } from '@web/components/calendar/calendar-view'
 import { DayViewPresentation } from '@web/components/day-view/day-view'
+import { useScheduleList } from '@web/hooks/use-schedules'
 import type { Task } from '@web/hooks/use-tasks'
 import { useTaskList } from '@web/hooks/use-tasks'
 import {
@@ -10,6 +11,7 @@ import {
   useUpdateTimeBlock,
 } from '@web/hooks/use-time-blocks'
 import { formatMinutes } from '@web/lib/format'
+import { scheduleColorToEventColor } from '@web/lib/schedule-color'
 import { useMemo } from 'react'
 
 export const Route = createFileRoute('/')({
@@ -24,6 +26,7 @@ function DayView() {
     return `${String(now.getFullYear())}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
   }, [])
   const { data: timeBlocksData } = useTimeBlocks(todayStr)
+  const { data: schedulesData } = useScheduleList(todayStr)
   const updateTimeBlock = useUpdateTimeBlock()
   const createTimeBlock = useCreateTimeBlock()
 
@@ -35,7 +38,7 @@ function DayView() {
     return map
   }, [categorized.all])
 
-  const calendarEvents: TimeBlockEvent[] = useMemo(() => {
+  const taskEvents: TimeBlockEvent[] = useMemo(() => {
     if (!timeBlocksData) return []
     return timeBlocksData
       .filter(
@@ -64,6 +67,31 @@ function DayView() {
         }
       })
   }, [timeBlocksData, taskMap])
+
+  const scheduleEvents: TimeBlockEvent[] = useMemo(() => {
+    if (!schedulesData) return []
+    return schedulesData.map((schedule) => {
+      const durationMs =
+        new Date(schedule.end).getTime() - new Date(schedule.start).getTime()
+      const durationMinutes = Math.round(durationMs / 60000)
+      const durationStr = formatMinutes(durationMinutes)
+
+      return {
+        id: `schedule-${schedule.scheduleId}-${schedule.start}`,
+        title: schedule.title,
+        start: schedule.start,
+        end: schedule.end,
+        type: 'schedule' as const,
+        duration: durationStr,
+        color: scheduleColorToEventColor(schedule.color),
+      }
+    })
+  }, [schedulesData])
+
+  const calendarEvents: TimeBlockEvent[] = useMemo(
+    () => [...taskEvents, ...scheduleEvents],
+    [taskEvents, scheduleEvents],
+  )
 
   const dndCallbacks: CalendarDndCallbacks = useMemo(
     () => ({


### PR DESCRIPTION
## Why

- Recurring schedules should be visible on the Day View calendar alongside task time blocks

## What

- Fetch expanded schedule data from `GET /api/schedule/recurring` and render them as calendar events together with task time blocks
- Schedule blocks are visually distinguished from task blocks by colored background, left accent border, and repeat icon

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/tq/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
