### PR TITLE
web: add Cmd+K command palette search modal

### DIFF
--- a/web/src/components/layout/app-layout.tsx
+++ b/web/src/components/layout/app-layout.tsx
@@ -7,7 +7,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
   const [searchOpen, setSearchOpen] = useState(false)
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
-    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault()
       setSearchOpen((prev) => !prev)
     }

--- a/web/src/components/layout/app-layout.tsx
+++ b/web/src/components/layout/app-layout.tsx
@@ -1,13 +1,31 @@
 import { BottomTabBar } from '@web/components/layout/bottom-tab-bar'
 import { Sidebar } from '@web/components/layout/sidebar'
-import type { ReactNode } from 'react'
+import { SearchModal } from '@web/components/search/search-modal'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
 
 export function AppLayout({ children }: { children: ReactNode }) {
+  const [searchOpen, setSearchOpen] = useState(false)
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+      e.preventDefault()
+      setSearchOpen((prev) => !prev)
+    }
+  }, [])
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [handleKeyDown])
+
   return (
     <div className="flex h-screen">
       <Sidebar />
       <main className="flex-1 overflow-auto pb-14 md:pb-0">{children}</main>
       <BottomTabBar />
+      <SearchModal open={searchOpen} onOpenChange={setSearchOpen} />
     </div>
   )
 }

--- a/web/src/components/search/search-modal.stories.tsx
+++ b/web/src/components/search/search-modal.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router'
+import { SearchModal } from '@web/components/search/search-modal'
+import type { ReactNode } from 'react'
+import { useState } from 'react'
+
+function Providers({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  const rootRoute = createRootRoute({
+    component: () => <>{children}</>,
+  })
+  const indexRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: () => null,
+  })
+  const taskRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/tasks/$taskId',
+    component: () => null,
+  })
+  rootRoute.addChildren([indexRoute, taskRoute])
+
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  )
+}
+
+function SearchModalStory() {
+  const [open, setOpen] = useState(true)
+  return (
+    <Providers>
+      <div className="flex h-screen items-center justify-center bg-background">
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(true)
+          }}
+          className="rounded-lg bg-secondary px-4 py-2 text-sm text-foreground"
+        >
+          Open Search (Cmd+K)
+        </button>
+        <SearchModal open={open} onOpenChange={setOpen} />
+      </div>
+    </Providers>
+  )
+}
+
+const meta = {
+  title: 'Search/SearchModal',
+  component: SearchModalStory,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof SearchModalStory>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/web/src/components/search/search-modal.test.tsx
+++ b/web/src/components/search/search-modal.test.tsx
@@ -1,0 +1,248 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SearchModal } from '@web/components/search/search-modal'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockTasks = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    title: 'Implement task list UI',
+    description: null,
+    status: 'todo' as const,
+    context: 'dev' as const,
+    startDate: null,
+    dueDate: null,
+    estimatedMinutes: 120,
+    parentId: null,
+    projectId: null,
+    sortOrder: 0,
+    recurrenceRuleId: null,
+    recurrenceRule: null,
+    createdAt: '2026-03-20T00:00:00.000Z',
+    updatedAt: '2026-03-20T00:00:00.000Z',
+    activeTimeBlockStartTime: null,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000002',
+    title: 'Review pull request',
+    description: null,
+    status: 'in_progress' as const,
+    context: 'work' as const,
+    startDate: null,
+    dueDate: null,
+    estimatedMinutes: 30,
+    parentId: null,
+    projectId: null,
+    sortOrder: 1,
+    recurrenceRuleId: null,
+    recurrenceRule: null,
+    createdAt: '2026-03-20T00:00:00.000Z',
+    updatedAt: '2026-03-20T00:00:00.000Z',
+    activeTimeBlockStartTime: null,
+  },
+]
+
+const mockSuggestions = [
+  { value: 'is:todo', display: 'Todo', category: 'is' },
+  { value: 'is:in_progress', display: 'In Progress', category: 'is' },
+]
+
+let mockSearchData: typeof mockTasks = []
+let mockSuggestionData: typeof mockSuggestions = []
+
+vi.mock('@web/hooks/use-search', () => ({
+  useSearchTasks: () => ({
+    data: mockSearchData.length > 0 ? mockSearchData : undefined,
+    isFetching: false,
+  }),
+  useSearchSuggestions: () => ({
+    data: mockSuggestionData.length > 0 ? mockSuggestionData : undefined,
+  }),
+}))
+
+const mockNavigate = vi.fn()
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
+
+function renderSearchModal(
+  props: {
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  } = {},
+) {
+  const onOpenChange = props.onOpenChange ?? vi.fn()
+
+  return {
+    onOpenChange,
+    ...render(
+      <Wrapper>
+        <SearchModal open={props.open ?? true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    ),
+  }
+}
+
+describe('SearchModal', () => {
+  beforeEach(() => {
+    mockSearchData = []
+    mockSuggestionData = []
+    mockNavigate.mockClear()
+  })
+
+  it('renders the search input when open', () => {
+    renderSearchModal()
+    expect(screen.getByLabelText('Search tasks')).toBeInTheDocument()
+  })
+
+  it('shows initial empty state', () => {
+    renderSearchModal()
+    expect(screen.getByText('Type to search tasks...')).toBeInTheDocument()
+  })
+
+  it('does not render when closed', () => {
+    renderSearchModal({ open: false })
+    expect(screen.queryByLabelText('Search tasks')).not.toBeInTheDocument()
+  })
+
+  it('calls onOpenChange(false) when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderSearchModal({ onOpenChange })
+
+    await user.keyboard('{Escape}')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('shows search results when data is available', async () => {
+    mockSearchData = mockTasks
+
+    const user = userEvent.setup()
+    renderSearchModal()
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'task')
+
+    expect(screen.getByText('Implement task list UI')).toBeInTheDocument()
+    expect(screen.getByText('Review pull request')).toBeInTheDocument()
+  })
+
+  it('shows suggestions when data is available', async () => {
+    mockSuggestionData = mockSuggestions
+
+    const user = userEvent.setup()
+    renderSearchModal()
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'is:')
+
+    expect(screen.getByText('is:todo')).toBeInTheDocument()
+    expect(screen.getByText('is:in_progress')).toBeInTheDocument()
+  })
+
+  it('navigates results with arrow keys', async () => {
+    mockSearchData = mockTasks
+
+    const user = userEvent.setup()
+    renderSearchModal()
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'task')
+
+    const options = screen.getAllByRole('option')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+
+    await user.keyboard('{ArrowDown}')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+    expect(options[0]).toHaveAttribute('aria-selected', 'false')
+
+    await user.keyboard('{ArrowUp}')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('applies suggestion with Tab key', async () => {
+    mockSuggestionData = mockSuggestions
+
+    const user = userEvent.setup()
+    renderSearchModal()
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'is:')
+
+    await user.keyboard('{Tab}')
+    expect(input).toHaveValue('is:todo ')
+  })
+
+  it('shows no results message when search returns empty and query is typed', async () => {
+    const user = userEvent.setup()
+    renderSearchModal()
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'nonexistent')
+
+    expect(screen.getByText('No results found')).toBeInTheDocument()
+  })
+
+  it('shows keyboard hints in footer', () => {
+    renderSearchModal()
+    expect(screen.getByText(/navigate/)).toBeInTheDocument()
+    expect(screen.getByText(/autocomplete/)).toBeInTheDocument()
+  })
+
+  it('wraps around when navigating past the last item', async () => {
+    mockSearchData = mockTasks
+
+    const user = userEvent.setup()
+    renderSearchModal()
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'task')
+
+    const options = screen.getAllByRole('option')
+
+    await user.keyboard('{ArrowDown}')
+    expect(options[1]).toHaveAttribute('aria-selected', 'true')
+
+    await user.keyboard('{ArrowDown}')
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('closes modal and navigates to task on Enter', async () => {
+    mockSearchData = mockTasks
+    const onOpenChange = vi.fn()
+
+    const user = userEvent.setup()
+    renderSearchModal({ onOpenChange })
+
+    const input = screen.getByLabelText('Search tasks')
+    await user.type(input, 'task')
+
+    await user.keyboard('{Enter}')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(mockNavigate).toHaveBeenCalledWith({
+      to: '/tasks/$taskId',
+      params: { taskId: '00000000-0000-0000-0000-000000000001' },
+    })
+  })
+
+  it('closes modal when clicking backdrop', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+    renderSearchModal({ onOpenChange })
+
+    const overlay = screen.getByTestId('search-overlay')
+    await user.click(overlay)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/web/src/components/search/search-modal.tsx
+++ b/web/src/components/search/search-modal.tsx
@@ -1,0 +1,352 @@
+import { useNavigate } from '@tanstack/react-router'
+import type { SearchResult, Suggestion } from '@web/hooks/use-search'
+import { useSearchSuggestions, useSearchTasks } from '@web/hooks/use-search'
+import { formatMinutes } from '@web/lib/format'
+import { cn } from '@web/lib/utils'
+import {
+  CircleCheckBig,
+  CircleDot,
+  Loader2,
+  Search,
+  Square,
+} from 'lucide-react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+interface SearchModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+type ListItem =
+  | { type: 'suggestion'; data: Suggestion }
+  | { type: 'task'; data: SearchResult }
+
+function StatusIcon({ status }: { status: SearchResult['status'] }) {
+  if (status === 'completed') {
+    return (
+      <CircleCheckBig className="h-[18px] w-[18px] shrink-0 text-muted-foreground" />
+    )
+  }
+  if (status === 'in_progress') {
+    return <CircleDot className="h-[18px] w-[18px] shrink-0 text-primary" />
+  }
+  return <Square className="h-[18px] w-[18px] shrink-0 text-muted-foreground" />
+}
+
+function ContextBadge({ context }: { context: SearchResult['context'] }) {
+  if (context === 'personal') return null
+
+  return (
+    <span
+      className={cn(
+        'rounded-[10px] px-2 py-0.5 text-[11px] font-medium',
+        context === 'work' && 'bg-[#3D2020] text-[#FF5C33]',
+        context === 'dev' && 'bg-[#1A2040] text-[#B2B2FF]',
+      )}
+    >
+      {context}
+    </span>
+  )
+}
+
+function extractCurrentPrefix(query: string): string {
+  const parts = query.split(/\s+/)
+  const last = parts[parts.length - 1] ?? ''
+  if (last.includes(':') && !last.endsWith(':')) return ''
+  return last
+}
+
+export function SearchModal({ open, onOpenChange }: SearchModalProps) {
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+
+  const { data: tasks, isFetching } = useSearchTasks(query)
+
+  const currentPrefix = extractCurrentPrefix(query)
+  const { data: suggestions } = useSearchSuggestions(currentPrefix)
+
+  const items = useMemo((): ListItem[] => {
+    const result: ListItem[] = []
+    if (suggestions && currentPrefix.length > 0) {
+      for (const s of suggestions) {
+        result.push({ type: 'suggestion', data: s })
+      }
+    }
+    if (tasks) {
+      for (const t of tasks) {
+        result.push({ type: 'task', data: t })
+      }
+    }
+    return result
+  }, [suggestions, tasks, currentPrefix])
+
+  useEffect(() => {
+    setSelectedIndex(0)
+  }, [items.length])
+
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setSelectedIndex(0)
+    }
+  }, [open])
+
+  // Scroll selected item into view
+  useEffect(() => {
+    if (listRef.current == null) return
+    const selected = listRef.current.querySelector('[data-selected="true"]')
+    if (typeof selected?.scrollIntoView === 'function') {
+      selected.scrollIntoView({ block: 'nearest' })
+    }
+  }, [selectedIndex])
+
+  const applySuggestion = useCallback(
+    (suggestion: Suggestion) => {
+      const parts = query.split(/\s+/)
+      parts[parts.length - 1] = suggestion.value
+      const newQuery = parts.join(' ') + ' '
+      setQuery(newQuery)
+      inputRef.current?.focus()
+    },
+    [query],
+  )
+
+  const openTask = useCallback(
+    (task: SearchResult) => {
+      onOpenChange(false)
+      void navigate({ to: '/tasks/$taskId', params: { taskId: task.id } })
+    },
+    [navigate, onOpenChange],
+  )
+
+  const handleSelect = useCallback(
+    (index: number) => {
+      const item = items[index]
+      if (item == null) return
+      if (item.type === 'suggestion') {
+        applySuggestion(item.data)
+      } else {
+        openTask(item.data)
+      }
+    },
+    [items, applySuggestion, openTask],
+  )
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0))
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1))
+        break
+      case 'Enter':
+        e.preventDefault()
+        handleSelect(selectedIndex)
+        break
+      case 'Tab':
+        e.preventDefault()
+        if (items[selectedIndex]?.type === 'suggestion') {
+          handleSelect(selectedIndex)
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        onOpenChange(false)
+        break
+    }
+  }
+
+  const hasSuggestions =
+    suggestions != null && suggestions.length > 0 && currentPrefix.length > 0
+  const hasTasks = tasks != null && tasks.length > 0
+
+  if (!open) return null
+
+  return createPortal(
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-50 bg-black/50"
+        data-testid="search-overlay"
+        onClick={() => {
+          onOpenChange(false)
+        }}
+      />
+
+      {/* Modal */}
+      <div
+        className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+        onKeyDown={handleKeyDown}
+        data-testid="search-modal"
+      >
+        <div
+          className="flex max-h-[480px] w-full max-w-[640px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl"
+          role="dialog"
+          aria-label="Search"
+        >
+          {/* Search input */}
+          <div className="flex h-12 items-center gap-3 border-b border-border px-4">
+            <Search className="h-[18px] w-[18px] shrink-0 text-muted-foreground" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value)
+              }}
+              placeholder="Search tasks..."
+              autoFocus
+              className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              aria-label="Search tasks"
+            />
+            {isFetching && (
+              <Loader2
+                className="h-4 w-4 shrink-0 animate-spin text-muted-foreground"
+                data-testid="search-loading"
+              />
+            )}
+            <kbd className="flex shrink-0 items-center rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground">
+              Esc
+            </kbd>
+          </div>
+
+          {/* Results list */}
+          <div
+            ref={listRef}
+            className="flex-1 overflow-y-auto py-2"
+            role="listbox"
+            aria-label="Search results"
+          >
+            {/* Suggestions section */}
+            {hasSuggestions && (
+              <>
+                <div className="px-4 py-1 text-[11px] font-medium text-muted-foreground">
+                  Suggestions
+                </div>
+                {suggestions.map((suggestion, i) => {
+                  const globalIndex = i
+                  return (
+                    <button
+                      type="button"
+                      key={suggestion.value}
+                      role="option"
+                      aria-selected={selectedIndex === globalIndex}
+                      data-selected={selectedIndex === globalIndex}
+                      onClick={() => {
+                        applySuggestion(suggestion)
+                      }}
+                      onMouseEnter={() => {
+                        setSelectedIndex(globalIndex)
+                      }}
+                      className={cn(
+                        'flex w-full items-center gap-2 px-4 py-2 text-left',
+                        selectedIndex === globalIndex
+                          ? 'bg-secondary'
+                          : 'hover:bg-secondary/50',
+                      )}
+                    >
+                      <span className="font-mono text-[13px] text-foreground">
+                        {suggestion.value}
+                      </span>
+                      <span className="text-[11px] text-muted-foreground">
+                        {suggestion.display}
+                      </span>
+                    </button>
+                  )
+                })}
+              </>
+            )}
+
+            {/* Divider between suggestions and tasks */}
+            {hasSuggestions && hasTasks && (
+              <div className="mx-4 my-1 h-px bg-border" />
+            )}
+
+            {/* Tasks section */}
+            {hasTasks && (
+              <>
+                <div className="px-4 py-1 text-[11px] font-medium text-muted-foreground">
+                  Tasks
+                </div>
+                {tasks.map((task, i) => {
+                  const globalIndex =
+                    (hasSuggestions ? suggestions.length : 0) + i
+                  return (
+                    <button
+                      type="button"
+                      key={task.id}
+                      role="option"
+                      aria-selected={selectedIndex === globalIndex}
+                      data-selected={selectedIndex === globalIndex}
+                      onClick={() => {
+                        openTask(task)
+                      }}
+                      onMouseEnter={() => {
+                        setSelectedIndex(globalIndex)
+                      }}
+                      className={cn(
+                        'flex w-full items-center gap-3 px-4 py-3 text-left',
+                        selectedIndex === globalIndex
+                          ? 'bg-secondary'
+                          : 'hover:bg-secondary/50',
+                        task.status === 'completed' && 'opacity-50',
+                      )}
+                    >
+                      <StatusIcon status={task.status} />
+                      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <span className="truncate text-sm font-medium text-foreground">
+                          {task.title}
+                        </span>
+                        <div className="flex items-center gap-1.5">
+                          <ContextBadge context={task.context} />
+                          {task.estimatedMinutes != null && (
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {formatMinutes(task.estimatedMinutes)}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </button>
+                  )
+                })}
+              </>
+            )}
+
+            {/* Empty state */}
+            {query.length > 0 &&
+              !isFetching &&
+              !hasTasks &&
+              !hasSuggestions && (
+                <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                  No results found
+                </div>
+              )}
+
+            {/* Initial state */}
+            {query.length === 0 && (
+              <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+                Type to search tasks...
+              </div>
+            )}
+          </div>
+
+          {/* Footer with keyboard hints */}
+          <div className="flex h-9 items-center border-t border-border px-4">
+            <span className="font-mono text-[11px] text-muted-foreground">
+              <kbd>↑↓</kbd> navigate <kbd>Tab</kbd> autocomplete{' '}
+              <kbd>Enter</kbd> open <kbd>Esc</kbd> close
+            </span>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/web/src/components/search/search-modal.tsx
+++ b/web/src/components/search/search-modal.tsx
@@ -171,20 +171,16 @@ export function SearchModal({ open, onOpenChange }: SearchModalProps) {
 
   return createPortal(
     <>
-      {/* Backdrop */}
+      {/* Backdrop + Modal wrapper (single layer to avoid z-index stacking issues) */}
       <div
-        className="fixed inset-0 z-50 bg-black/50"
+        className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 pt-[15vh]"
         data-testid="search-overlay"
-        onClick={() => {
-          onOpenChange(false)
-        }}
-      />
-
-      {/* Modal */}
-      <div
-        className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
         onKeyDown={handleKeyDown}
-        data-testid="search-modal"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            onOpenChange(false)
+          }
+        }}
       >
         <div
           className="flex max-h-[480px] w-full max-w-[640px] flex-col overflow-hidden rounded-xl border border-border bg-card shadow-2xl"

--- a/web/src/components/search/search-modal.tsx
+++ b/web/src/components/search/search-modal.tsx
@@ -62,6 +62,7 @@ export function SearchModal({ open, onOpenChange }: SearchModalProps) {
   const [selectedIndex, setSelectedIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
+  const lastMousePos = useRef({ x: 0, y: 0 })
   const navigate = useNavigate()
 
   const { data: tasks, isFetching } = useSearchTasks(query)
@@ -86,7 +87,7 @@ export function SearchModal({ open, onOpenChange }: SearchModalProps) {
 
   useEffect(() => {
     setSelectedIndex(0)
-  }, [items.length])
+  }, [items])
 
   useEffect(() => {
     if (open) {
@@ -165,7 +166,7 @@ export function SearchModal({ open, onOpenChange }: SearchModalProps) {
 
   const hasSuggestions =
     suggestions != null && suggestions.length > 0 && currentPrefix.length > 0
-  const hasTasks = tasks != null && tasks.length > 0
+  const hasTasks = query.length > 0 && tasks != null && tasks.length > 0
 
   if (!open) return null
 
@@ -238,8 +239,17 @@ export function SearchModal({ open, onOpenChange }: SearchModalProps) {
                       onClick={() => {
                         applySuggestion(suggestion)
                       }}
-                      onMouseEnter={() => {
-                        setSelectedIndex(globalIndex)
+                      onMouseMove={(e) => {
+                        if (
+                          e.clientX !== lastMousePos.current.x ||
+                          e.clientY !== lastMousePos.current.y
+                        ) {
+                          lastMousePos.current = {
+                            x: e.clientX,
+                            y: e.clientY,
+                          }
+                          setSelectedIndex(globalIndex)
+                        }
                       }}
                       className={cn(
                         'flex w-full items-center gap-2 px-4 py-2 text-left',
@@ -284,8 +294,17 @@ export function SearchModal({ open, onOpenChange }: SearchModalProps) {
                       onClick={() => {
                         openTask(task)
                       }}
-                      onMouseEnter={() => {
-                        setSelectedIndex(globalIndex)
+                      onMouseMove={(e) => {
+                        if (
+                          e.clientX !== lastMousePos.current.x ||
+                          e.clientY !== lastMousePos.current.y
+                        ) {
+                          lastMousePos.current = {
+                            x: e.clientX,
+                            y: e.clientY,
+                          }
+                          setSelectedIndex(globalIndex)
+                        }
                       }}
                       className={cn(
                         'flex w-full items-center gap-3 px-4 py-3 text-left',

--- a/web/src/hooks/use-search.ts
+++ b/web/src/hooks/use-search.ts
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '@web/lib/api'
+import { assertOk } from '@web/lib/assert-response'
+import type { InferResponseType } from 'hono/client'
+import { useEffect, useState } from 'react'
+
+type SearchResult = InferResponseType<
+  typeof api.api.tasks.search.$get,
+  200
+>[number]
+
+type Suggestion = InferResponseType<
+  (typeof api.api.tasks.search)['suggest']['$get'],
+  200
+>[number]
+
+export type { SearchResult, Suggestion }
+
+const searchKeys = {
+  all: ['search'] as const,
+  results: (q: string) => [...searchKeys.all, 'results', q] as const,
+  suggestions: (prefix: string) =>
+    [...searchKeys.all, 'suggestions', prefix] as const,
+}
+
+function useDebounce<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebounced(value)
+    }, delayMs)
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delayMs])
+
+  return debounced
+}
+
+export function useSearchTasks(query: string) {
+  const debouncedQuery = useDebounce(query, 200)
+
+  return useQuery({
+    queryKey: searchKeys.results(debouncedQuery),
+    queryFn: async () => {
+      const res = await api.api.tasks.search.$get({
+        query: { q: debouncedQuery, limit: '20' },
+      })
+      assertOk(res)
+      return res.json()
+    },
+    enabled: debouncedQuery.length > 0,
+    placeholderData: (prev) => prev,
+  })
+}
+
+export function useSearchSuggestions(prefix: string) {
+  const debouncedPrefix = useDebounce(prefix, 150)
+
+  return useQuery({
+    queryKey: searchKeys.suggestions(debouncedPrefix),
+    queryFn: async () => {
+      const res = await api.api.tasks.search.suggest.$get({
+        query: { prefix: debouncedPrefix },
+      })
+      assertOk(res)
+      return res.json()
+    },
+    enabled: debouncedPrefix.length > 0,
+  })
+}


### PR DESCRIPTION
## Why

- Allow quick task search and navigation via Cmd+K

## What

- Add a command palette-style search modal
  - Cmd+K (Mac) / Ctrl+K toggles the modal
  - Debounced real-time search with prefix-based autocomplete (`is:`, `context:`, and similar filters)
  - Keyboard navigation (arrow keys to select, Tab to apply suggestions, Enter to open task detail)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fohte/tq/pull/63" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
