### PR TITLE
ci/docker-publish: remove keel notification job

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -56,27 +56,3 @@ jobs:
           # Disable provenance to avoid ghcr.io permission_denied errors on private packages
           # ref: https://github.com/docker/build-push-action/issues/981
           provenance: false
-
-  notify-keel:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Connect to Tailscale
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
-        with:
-          oauth-client-id: ${{ secrets.TAILSCALE_CI_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TAILSCALE_CI_OAUTH_CLIENT_SECRET }}
-          tags: tag:ci
-
-      - name: Notify Keel
-        run: |
-          curl --fail -X POST \
-            -H 'Content-Type: application/json' \
-            -d '{"name": "ghcr.io/fohte/tq/api", "tag": "latest"}' \
-            "$KEEL_WEBHOOK_URL"
-          curl --fail -X POST \
-            -H 'Content-Type: application/json' \
-            -d '{"name": "ghcr.io/fohte/tq/web", "tag": "latest"}' \
-            "$KEEL_WEBHOOK_URL"
-        env:
-          KEEL_WEBHOOK_URL: ${{ secrets.KEEL_WEBHOOK_URL }}


### PR DESCRIPTION
## Purpose

- Keel has been retired

## Approach

- Remove the job that notifies keel for redeployment
