### PR TITLE
api: fix ESLint errors in the Google Calendar service

### DIFF
--- a/api/src/services/google-calendar.test.ts
+++ b/api/src/services/google-calendar.test.ts
@@ -20,7 +20,7 @@ function setEnv() {
 
 function clearEnv() {
   for (const key of Object.keys(MOCK_ENV)) {
-    delete process.env[key]
+    Reflect.deleteProperty(process.env, key)
   }
 }
 

--- a/api/src/services/google-calendar.ts
+++ b/api/src/services/google-calendar.ts
@@ -218,7 +218,7 @@ export async function getEvents(
   const data = googleCalendarEventsResponseSchema.parse(await response.json())
 
   return (data.items ?? []).map((event) => {
-    const isAllDay = event.start.dateTime == null || event.start.dateTime === ''
+    const isAllDay = event.start.dateTime == null
     return {
       id: event.id,
       summary: event.summary ?? '(No title)',

--- a/api/src/services/google-calendar.ts
+++ b/api/src/services/google-calendar.ts
@@ -53,7 +53,14 @@ function getConfig() {
   const clientSecret = process.env['GOOGLE_CLIENT_SECRET']
   const redirectUri = process.env['GOOGLE_REDIRECT_URI']
 
-  if (!clientId || !clientSecret || !redirectUri) {
+  if (
+    clientId == null ||
+    clientId === '' ||
+    clientSecret == null ||
+    clientSecret === '' ||
+    redirectUri == null ||
+    redirectUri === ''
+  ) {
     throw new Error(
       'GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and GOOGLE_REDIRECT_URI environment variables are required',
     )
@@ -163,7 +170,9 @@ export async function refreshTokenIfNeeded(): Promise<string> {
       accessToken: data.access_token,
       expiresAt,
       updatedAt: new Date(),
-      ...(data.refresh_token ? { refreshToken: data.refresh_token } : {}),
+      ...(data.refresh_token != null && data.refresh_token !== ''
+        ? { refreshToken: data.refresh_token }
+        : {}),
     })
     .where(eq(oauthTokens.id, token.id))
 
@@ -209,7 +218,7 @@ export async function getEvents(
   const data = googleCalendarEventsResponseSchema.parse(await response.json())
 
   return (data.items ?? []).map((event) => {
-    const isAllDay = !event.start.dateTime
+    const isAllDay = event.start.dateTime == null || event.start.dateTime === ''
     return {
       id: event.id,
       summary: event.summary ?? '(No title)',


### PR DESCRIPTION
## Purpose

- CI (lefthook eslint) is failing on main for `api/src/services/google-calendar.ts` and its test, blocking every PR branched off main from passing CI for the same reason
    - Failing job: https://github.com/fohte/tq/actions/runs/26357961703/job/77588068686

## Approach

- Rewrite the truthy checks on nullable strings as explicit null / empty-string checks
    - Align with the `value == null || value === ''` pattern in `api/src/env.ts`
- Replace the dynamic `delete process.env[key]` with `Reflect.deleteProperty`
    - Preserves the existing loop over `MOCK_ENV` in the test
